### PR TITLE
Parallelize + add "write" option

### DIFF
--- a/AbandonedStrings/main.swift
+++ b/AbandonedStrings/main.swift
@@ -169,7 +169,7 @@ if let rootDirectories = getRootDirectories() {
                 print("\n\nNow modifying \(stringsFilePath) ...")
                 let updatedStringsFileContent = stringsFile(stringsFilePath, without: map[stringsFilePath]!)
                 do {
-                    try updatedStringsFileContent.write(toFile: stringsFilePath, atomically: false, encoding: .utf8)
+                    try updatedStringsFileContent.write(toFile: stringsFilePath, atomically: true, encoding: .utf8)
                 } catch {
                     print("ERROR writing file: \(stringsFilePath)")
                 }

--- a/AbandonedStrings/main.swift
+++ b/AbandonedStrings/main.swift
@@ -109,9 +109,12 @@ func findAbandonedIdentifiersIn(_ rootDirectories: [String], withStoryboard: Boo
             if abandonedIdentifiers.isEmpty == false {
                 serialWriterQueue.async {
                     map[stringsFile] = abandonedIdentifiers
+                    dispatchGroup.leave()
                 }
+            } else {
+                NSLog("\(stringsFile) has no abandonedIdentifiers")
+                dispatchGroup.leave()
             }
-            dispatchGroup.leave()
         }
     }
     dispatchGroup.wait()


### PR DESCRIPTION
Hi there, thanks for making this!
It was missing 2 things I needed:
1) it was really slow (I have a large source-base), because it was confined to one thread. It is now parallelized so you can use all your CPU cores
2) I want this to (destructively) modify my strings files, so I added a "write" parameter. If "write" is present, it'll update the strings files.
I made separate commits for (1) and (2).
All the best
-tim
